### PR TITLE
Ajout du job Docker à la CI

### DIFF
--- a/.github/workflows/jest-ci.yml
+++ b/.github/workflows/jest-ci.yml
@@ -7,6 +7,30 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Goto client and run tests
         run: cd client && npm i && npm test
+
+  docker:
+    needs: test-front
+    if: github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          push: true
+          context: "{{defaultContext}}:client"
+          tags: ${{ secrets.DOCKERHUB_USERNAME }}/quete1902:latest


### PR DESCRIPTION
Ce workflow ajoute un job Docker après les tests Jest.
Il build et push une image Docker du client vers DockerHub lors d'un merge dans main.